### PR TITLE
Fix Wallet History Background changing to white

### DIFF
--- a/wallet/wallet/Views/Wallet Details/WalletDetails.swift
+++ b/wallet/wallet/Views/Wallet Details/WalletDetails.swift
@@ -113,7 +113,6 @@ struct WalletDetails: View {
         }
         .onDisappear() {
             UITableView.appearance().separatorStyle = .singleLine
-            UITableView.appearance().backgroundColor = UIColor.white
         }
         .edgesIgnoringSafeArea([.bottom])
         .navigationBarItems(trailing:


### PR DESCRIPTION
Fixes #92.

The background colour of the wallet history list was mistakenly being set to white. This PR fixes the bug.

I was not able to find any "CHANGELOG" file as mentioned in the contributor guide. Please let me know if there is a changelog somewhere else that needs to be updated.