### PR TITLE
fixing Pending Confirmations count (#133)

### DIFF
--- a/wallet/wallet.xcodeproj/project.pbxproj
+++ b/wallet/wallet.xcodeproj/project.pbxproj
@@ -123,7 +123,7 @@
 		0D11C23223BFA810001CF6F7 /* HostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostingController.swift; sourceTree = "<group>"; };
 		0D11C23423BFB33B001CF6F7 /* NavigationConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationConfigurator.swift; sourceTree = "<group>"; };
 		0D11C23623BFB666001CF6F7 /* ShareScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareScreen.swift; sourceTree = "<group>"; };
-		0D1250FF23B557E40014EE3A /* zECC Wallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "zECC Wallet.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0D1250FF23B557E40014EE3A /* ECC Wallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ECC Wallet.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D12510223B557E40014EE3A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0D12510423B557E40014EE3A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		0D12510823B557E60014EE3A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -282,7 +282,7 @@
 		0D12510023B557E40014EE3A /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				0D1250FF23B557E40014EE3A /* zECC Wallet.app */,
+				0D1250FF23B557E40014EE3A /* ECC Wallet.app */,
 				0D12511523B557E60014EE3A /* walletTests.xctest */,
 				0D12512023B557E60014EE3A /* walletUITests.xctest */,
 			);
@@ -453,7 +453,7 @@
 			);
 			name = wallet;
 			productName = wallet;
-			productReference = 0D1250FF23B557E40014EE3A /* zECC Wallet.app */;
+			productReference = 0D1250FF23B557E40014EE3A /* ECC Wallet.app */;
 			productType = "com.apple.product-type.application";
 		};
 		0D12511423B557E60014EE3A /* walletTests */ = {

--- a/wallet/wallet/Environment/CombineSynchronizer.swift
+++ b/wallet/wallet/Environment/CombineSynchronizer.swift
@@ -229,7 +229,7 @@ extension DetailModel {
         self.shielded = pendingTransaction.toAddress.isValidShieldedAddress
         self.status = .paid(success: pendingTransaction.isSubmitSuccess)
         if pendingTransaction.expiryHeight > 0, let latest = latestBlockHeight {
-            self.subtitle = "\(abs(latest - pendingTransaction.expiryHeight - ZcashSDK.EXPIRY_OFFSET)) of 10 Confirmations"
+            self.subtitle = "\(abs(latest - (pendingTransaction.expiryHeight - ZcashSDK.EXPIRY_OFFSET))) Confirmations"
         } else {
             self.subtitle = "Sent \(self.date.transactionDetail)"
         }

--- a/wallet/wallet/Environment/CombineSynchronizer.swift
+++ b/wallet/wallet/Environment/CombineSynchronizer.swift
@@ -222,8 +222,8 @@ extension DetailModel {
         self.id = pendingTransaction.rawTransactionId?.toHexStringTxId() ?? String(pendingTransaction.createTime)
         self.shielded = pendingTransaction.toAddress.isValidShieldedAddress
         self.status = .paid(success: pendingTransaction.isSubmitSuccess)
-        if pendingTransaction.expiryHeight > 0, let latest = latestBlockHeight {
-            self.subtitle = "\(abs(latest - (pendingTransaction.expiryHeight - ZcashSDK.EXPIRY_OFFSET))) Confirmations"
+        if pendingTransaction.minedHeight > 0, let latest = latestBlockHeight {
+            self.subtitle = "\(abs(latest - pendingTransaction.minedHeight)) Confirmations"
         } else {
             self.subtitle = "Sent \(self.date.transactionDetail)"
         }

--- a/wallet/wallet/Environment/CombineSynchronizer.swift
+++ b/wallet/wallet/Environment/CombineSynchronizer.swift
@@ -67,8 +67,7 @@ class CombineSynchronizer {
             }
         }
     }
-    
-    
+        
     init(initializer: Initializer) throws {
         
         self.synchronizer = try SDKSynchronizer(initializer: initializer)
@@ -87,7 +86,6 @@ class CombineSynchronizer {
             self.status.send(.syncing)
         }.store(in: &cancellables)
         
-        
         NotificationCenter.default.publisher(for: .synchronizerProgressUpdated).receive(on: DispatchQueue.main).sink(receiveValue: { (progressNotification) in
             guard let newProgress = progressNotification.userInfo?[SDKSynchronizer.NotificationKeys.progress] as? Float else { return }
             self.progress.send(newProgress)
@@ -95,7 +93,6 @@ class CombineSynchronizer {
             guard let blockHeight = progressNotification.userInfo?[SDKSynchronizer.NotificationKeys.blockHeight] as? BlockHeight else { return }
             self.syncBlockHeight.send(blockHeight)
         }).store(in: &cancellables)
-        
         
         NotificationCenter.default.publisher(for: .synchronizerMinedTransaction).sink(receiveValue: {minedNotification in
             guard let minedTx = minedNotification.userInfo?[SDKSynchronizer.NotificationKeys.minedTransaction] as? PendingTransactionEntity else { return }
@@ -143,7 +140,6 @@ class CombineSynchronizer {
         }
     }
     
-    
     func send(with spendingKey: String, zatoshi: Int64, to recipientAddress: String, memo: String?,from account: Int) -> Future<PendingTransactionEntity,Error>  {
         Future<PendingTransactionEntity, Error>() {
             promise in
@@ -173,10 +169,9 @@ extension CombineSynchronizer {
                 
                 do {
                     
-                    
                     let pending = try self.synchronizer.allPendingTransactions().map { DetailModel(pendingTransaction: $0, latestBlockHeight: self.syncBlockHeight.value) }
                     
-                    let txs = try self.synchronizer.allClearedTransactions().map {  DetailModel(confirmedTransaction: $0, sent: ($0.toAddress != nil)) }.filter({ s in
+                    let txs = try self.synchronizer.allClearedTransactions().map { DetailModel(confirmedTransaction: $0, sent: ($0.toAddress != nil)) }.filter({ s in
                         pending.first { (p) -> Bool in
                             p.id == s.id
                             } == nil })
@@ -201,7 +196,6 @@ extension CombineSynchronizer {
     }
 }
 
-
 extension Date {
     var transactionDetail: String {
         let formatter = DateFormatter()
@@ -219,7 +213,7 @@ extension DetailModel {
         self.subtitle = sent ? "Sent" : "Received" + " \(self.date.transactionDetail)"
         self.zAddress = confirmedTransaction.toAddress
         self.zecAmount = (sent ? -Int64(confirmedTransaction.value) : Int64(confirmedTransaction.value)).asHumanReadableZecBalance()
-        if let memo =  confirmedTransaction.memo {
+        if let memo = confirmedTransaction.memo {
             self.memo = String(bytes: memo, encoding: .utf8)
         }
     }
@@ -235,7 +229,7 @@ extension DetailModel {
         }
         self.zAddress = pendingTransaction.toAddress
         self.zecAmount = -Int64(pendingTransaction.value).asHumanReadableZecBalance()
-        if let memo =  pendingTransaction.memo {
+        if let memo = pendingTransaction.memo {
             self.memo = String(bytes: memo, encoding: .utf8)
         }
     }

--- a/wallet/walletTests/KeyPadViewModelTests.swift
+++ b/wallet/walletTests/KeyPadViewModelTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 import Combine
-@testable import zECC_Wallet
+@testable import ECC_Wallet
 class KeyPadViewModelTests: XCTestCase {
 
 

--- a/wallet/walletTests/NumberTests.swift
+++ b/wallet/walletTests/NumberTests.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import XCTest
-@testable import zECC_Wallet
+@testable import ECC_Wallet
 class NumberTests: XCTestCase {
     
     

--- a/wallet/walletTests/UILogicTests.swift
+++ b/wallet/walletTests/UILogicTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import zECC_Wallet
+@testable import ECC_Wallet
 class UILogicTests: XCTestCase {
 
   

--- a/wallet/walletTests/walletTests.swift
+++ b/wallet/walletTests/walletTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import zECC_Wallet
+@testable import ECC_Wallet
 import MnemonicSwift
 @testable import ZcashLightClientKit
 class walletTests: XCTestCase {


### PR DESCRIPTION
This fixes #133. Or at least the visual representation problem, number of confirmations count correctly now but outgoing transactions seem to stay pending (even after 130 confirmations). 

Testnet transaction I used for testing: 209d05f389498591a4955ff87a5370c9b74ad1f1ae581b5d5011f2f80fe60022
![image](https://user-images.githubusercontent.com/129620/86279415-4306b880-bbda-11ea-9ff6-d86a23607c5e.png)
