### PR TITLE
ZcashLightClientKit Beta 4 update

### DIFF
--- a/wallet/Podfile
+++ b/wallet/Podfile
@@ -2,7 +2,7 @@ platform :ios, '14.1'
 use_frameworks!
 
 def base_pods
-  pod 'ZcashLightClientKit', :git => 'https://github.com/zcash/ZcashLightClientKit.git', :tag => '0.12.0-beta.3'
+  pod 'ZcashLightClientKit', :git => 'https://github.com/zcash/ZcashLightClientKit.git', :tag => '0.12.0-beta.4'
 #  pod 'ZcashLightClientKit', :path => '../../ZcashLightClientKit'
   pod 'gRPC-Swift', '= 1.0.0'
   pod 'KeychainSwift', '~> 19.0.0'

--- a/wallet/Podfile.lock
+++ b/wallet/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
     - SwiftNIOTLS (< 3, >= 2.27.0)
   - SwiftProtobuf (1.17.0)
   - TinyQRScanner (1.0.1)
-  - ZcashLightClientKit (0.12.0-beta.3):
+  - ZcashLightClientKit (0.12.0-beta.4):
     - gRPC-Swift (= 1.0.0)
     - SQLite.swift (~> 0.12.2)
   - zealous-logger (1.0.0):
@@ -87,7 +87,7 @@ DEPENDENCIES:
   - Mixpanel-swift
   - MnemonicSwift (from `https://github.com/zcash-hackworks/MnemonicSwift.git`, branch `master`)
   - TinyQRScanner
-  - ZcashLightClientKit (from `https://github.com/zcash/ZcashLightClientKit.git`, tag `0.12.0-beta.3`)
+  - ZcashLightClientKit (from `https://github.com/zcash/ZcashLightClientKit.git`, tag `0.12.0-beta.4`)
   - zealous-logger (from `https://github.com/zcash-hackworks/zealous-logger`, branch `master`)
 
 SPEC REPOS:
@@ -128,7 +128,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/zcash-hackworks/MnemonicSwift.git
   ZcashLightClientKit:
     :git: https://github.com/zcash/ZcashLightClientKit.git
-    :tag: 0.12.0-beta.3
+    :tag: 0.12.0-beta.4
   zealous-logger:
     :branch: master
     :git: https://github.com/zcash-hackworks/zealous-logger
@@ -139,7 +139,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/zcash-hackworks/MnemonicSwift.git
   ZcashLightClientKit:
     :git: https://github.com/zcash/ZcashLightClientKit.git
-    :tag: 0.12.0-beta.3
+    :tag: 0.12.0-beta.4
   zealous-logger:
     :commit: c9f8d8d9f74a456094b9143616da3b4eba91ddcf
     :git: https://github.com/zcash-hackworks/zealous-logger
@@ -175,9 +175,9 @@ SPEC CHECKSUMS:
   SwiftNIOTransportServices: eee29d06a617e6b37c534d8589ae27c31b119f81
   SwiftProtobuf: 9c85136c6ba74b0a1b84279dbf0f6db8efb714e0
   TinyQRScanner: 4077088ff2e8d476af79e6035413648c2c7900ef
-  ZcashLightClientKit: 6583f027ce90d860e51884116034e9e7074cb2e1
+  ZcashLightClientKit: dc087f89eb8924a467d5962623a00d7d81245a17
   zealous-logger: 2f33820d7d7e723796dabc51d60942b51b9ab024
 
-PODFILE CHECKSUM: 69768261c6525c4aea52442970a06c00e1f8be93
+PODFILE CHECKSUM: 6fdfd078076dd8dee1182cbfc936c1e3da4610f5
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.0


### PR DESCRIPTION
This PR brings the AutoShielding branch up to date, referencing the beta 4 branch of ZcashLightClientKit. 

*Note that this PR is not being merged into master but onto the existing AutoShielding branch.